### PR TITLE
Add ability to specify what key type to search for with ssh-keyscan

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ man-in-the-middle'd.
 
 Does UDP hole punching through hyperswarm so it's great for making your office server available over ssh
 even if that server is behind a firewall
+## Options
+
+```sh
+hyperssh-server [user?] [type?]
+```
+
+Run the server to login as the given user and use the given fingerprint type. By default chooses a random key from the available keys on your system. Passing the fingerprint type option allows for consistent results across restarts of the server.
+
+```sh
+hyperssh [type] [signature] [user?] [ssh-options...]
+```
 
 ## License
 

--- a/server.js
+++ b/server.js
@@ -7,9 +7,20 @@ const pump = require('pump')
 const os = require('os')
 
 let fingerprint
+const keyTypes = ['dsa', 'ecdsa', 'ed25519', 'rsa']
+let optStr = ''
+if (process.argv.length > 3) {
+  const key = process.argv[3]
+  if (keyTypes.includes(key)) {
+    optStr = '-t ' + key + ' '
+  } else {
+    console.log('Usage hyperssh-server [user?] [dsa|ecdsa|ed25519|rsa?]')
+    process.exit(2)
+  }
+}
 
 try {
-  fingerprint = execSync('ssh-keyscan localhost', { stdio: ['ignore', null, 'ignore'] }).toString().split('\n')
+  fingerprint = execSync('ssh-keyscan ' + optStr + 'localhost', { stdio: ['ignore', null, 'ignore'] }).toString().split('\n')
     .map(l => l.trim())
     .filter(l => l[0] !== '#')[0].split(' ').slice(1).join(' ')
 } catch (err) {


### PR DESCRIPTION
Solves Issue #1, but allows for specifying more key types than PR #2. The available types were derived from [the BSD documentation for ssh-keyscan](https://man.openbsd.org/ssh-keyscan.1).
