### PR TITLE
Change `//` comments to `#` so copy-n-paste works

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ SSH and SSHFS over the [Hyperswarm DHT](https://github.com/holepunchto/hyperdht)
 
 ## Installation
 ```
-npm install -g hyperssh // ssh / fuse client stubs
-npm install -g hypertele // hyperswarm server proxy
-npm install -g hyper-cmd-utils // keygen utils
+npm install -g hyperssh # ssh / fuse client stubs
+npm install -g hypertele # hyperswarm server proxy
+npm install -g hyper-cmd-utils # keygen utils
 ```
 
 ## Usage


### PR DESCRIPTION
A minor fix to the README.md so copy & pasting the installation instructions work. Currently has the wrong comment style.